### PR TITLE
Render parapgraphs with <Text /> component

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -204,7 +204,7 @@ export default styles => ({
   paragraph: {
     react: (node, output, state) =>
       createElement(
-        View,
+        Text,
         {
           key: state.key,
           style: styles.paragraph,


### PR DESCRIPTION
To avoid weird formatting when rendering text. This should fix https://github.com/GetStream/stream-chat-react-native/issues/209.

**Before**:

<img width="350" alt="Screenshot 2020-05-12 at 17 01 29" src="https://user-images.githubusercontent.com/1326024/81709692-587d2300-9472-11ea-88bb-a4e5c23afdf2.png">

**After**:

<img width="350" alt="Screenshot 2020-05-12 at 16 59 07" src="https://user-images.githubusercontent.com/1326024/81709719-5f0b9a80-9472-11ea-82ae-2301c51a3eab.png">

